### PR TITLE
Remove server_name variable from the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ JSON-RPC endpoints for SKALE chains. It is based on NGINX.
 #### Required environment variables
 
 - `ENDPOINT` - endpoint of the Ethereum network where `skale-manager` contracts are deployed
-- `SERVER_NAME` - domain name of the server
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   skale-proxy:
     environment:
-      SERVER_NAME: ${SERVER_NAME}
       ETH_ENDPOINT: ${ETH_ENDPOINT}
     image: skale-proxy:latest
     container_name: proxy_admin

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -46,8 +46,6 @@ UPSTREAMS_FOLDER = os.path.join(PROJECT_PATH, 'conf', 'upstreams')
 TMP_CHAINS_FOLDER = os.path.join(PROJECT_PATH, 'conf', 'tmp_chains')
 TMP_UPSTREAMS_FOLDER = os.path.join(PROJECT_PATH, 'conf', 'tmp_upstreams')
 
-SERVER_NAME = os.environ['SERVER_NAME']
-
 PROXY_LOG_FORMAT = '[%(asctime)s] %(process)d %(levelname)s %(module)s: %(message)s'
 LONG_LINE = '=' * 100
 

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -26,7 +26,7 @@ from proxy.endpoints import generate_endpoints
 from proxy.helper import init_default_logger, write_json
 from proxy.str_formatters import arguments_list_string
 from proxy.config import (
-    CHAINS_INFO_FILEPATH, MONITOR_INTERVAL, ENDPOINT, SM_ABI_FILEPATH, SERVER_NAME,
+    CHAINS_INFO_FILEPATH, MONITOR_INTERVAL, ENDPOINT, SM_ABI_FILEPATH,
     TMP_CHAINS_FOLDER, TMP_UPSTREAMS_FOLDER
 )
 
@@ -37,8 +37,7 @@ logger = logging.getLogger(__name__)
 def main():
     init_default_logger()
     logger.info(arguments_list_string({
-        'Endpoint': ENDPOINT,
-        'Server name': SERVER_NAME
+        'Endpoint': ENDPOINT
         }, 'Starting SKALE Proxy server'))
 
     Path(TMP_CHAINS_FOLDER).mkdir(parents=True, exist_ok=True)

--- a/proxy/nginx.py
+++ b/proxy/nginx.py
@@ -26,7 +26,7 @@ import docker
 
 from proxy.helper import process_template
 from proxy.config import (
-    SCHAIN_NGINX_TEMPLATE, UPSTREAM_NGINX_TEMPLATE, CHAINS_FOLDER, UPSTREAMS_FOLDER, SERVER_NAME,
+    SCHAIN_NGINX_TEMPLATE, UPSTREAM_NGINX_TEMPLATE, CHAINS_FOLDER, UPSTREAMS_FOLDER,
     NGINX_CONTAINER_NAME, CONTAINER_RUNNING_STATUS, TMP_CHAINS_FOLDER, TMP_UPSTREAMS_FOLDER
 )
 
@@ -84,13 +84,12 @@ def generate_nginx_configs(schains_endpoints: list) -> None:
         if not schain_endpoints:
             continue
         logger.info(f'Processing template for {schain_endpoints["chain_info"]["schain_name"]}...')
-        process_nginx_config_template(schain_endpoints['chain_info'], SERVER_NAME)
+        process_nginx_config_template(schain_endpoints['chain_info'])
 
 
-def process_nginx_config_template(chain_info: dict, server_name: str) -> None:
+def process_nginx_config_template(chain_info: dict) -> None:
     chain_dest = os.path.join(TMP_CHAINS_FOLDER, f'{chain_info["schain_name"]}.conf')
     upstream_dest = os.path.join(TMP_UPSTREAMS_FOLDER, f'{chain_info["schain_name"]}.conf')
-    chain_info['server_name'] = server_name
     process_template(SCHAIN_NGINX_TEMPLATE, chain_dest, chain_info)
     process_template(UPSTREAM_NGINX_TEMPLATE, upstream_dest, chain_info)
 

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -5,7 +5,6 @@ set -e
 export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 : "${ENDPOINT?Need to set ENDPOINT}"
-: "${SERVER_NAME?Need to set SERVER_NAME}"
 
 cd $DIR/..
 docker-compose up --build -d


### PR DESCRIPTION
This PR removes the deprecated `SERVER_NAME` variable from the SKALE Proxy setup.
README is updated to match the current setup process.

No tests needed.
No performance changes.