### PR TITLE
Update proxy upstream limits, add heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ JSON-RPC endpoints for SKALE chains. It is based on NGINX.
 
 - `ETH_ENDPOINT` - endpoint of the Ethereum network where `skale-manager` contracts are deployed
 
+#### Optional environment variables
+
+- `HEARTBEAT_URL` - URL for healthcheck endpoint (optional)
+
 ## License
 
 [![License](https://img.shields.io/github/license/skalenetwork/skale-proxy.svg)](LICENSE)

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -20,9 +20,9 @@ http {
 
 		limit_req zone=one burst=100;
 
-		proxy_read_timeout 180s;
-    	proxy_connect_timeout 60s;
-    	proxy_send_timeout 180s;	
+		proxy_read_timeout 60s;
+		proxy_connect_timeout 30s;
+		proxy_send_timeout 60s;
 
 		location / {
 			proxy_http_version 1.1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   skale-proxy:
     environment:
       ETH_ENDPOINT: ${ETH_ENDPOINT}
+      HEARTBEAT_URL: ${HEARTBEAT_URL}
     image: skale-proxy:latest
     container_name: proxy_admin
     build:

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -27,6 +27,8 @@ PORTS_PER_SCHAIN = 64
 
 MONITOR_INTERVAL = os.getenv('MONITOR_INTERVAL', 60 * 60 * 2)
 
+HEARTBEAT_URL = os.getenv('HEARTBEAT_URL')
+
 NGINX_WWW_FOLDER = os.path.join(PROJECT_PATH, 'www')
 CHAINS_INFO_FILEPATH = os.path.join(NGINX_WWW_FOLDER, 'chains.json')
 

--- a/proxy/heartbeat.py
+++ b/proxy/heartbeat.py
@@ -1,0 +1,36 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE Proxy
+#
+#   Copyright (C) 2024-Present SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def send_heartbeat(heartbeat_url):
+    if heartbeat_url is None:
+        logger.info('HEARTBEAT_URL is not set on the proxy')
+    try:
+        response = requests.get(heartbeat_url)
+        if response.status_code == 200:
+            logger.info('Heartbeat signal is successfully sent')
+        else:
+            logger.warning(f'Failed to send heartbeat signal: {response.status_code}')
+    except Exception as e:
+        logger.error(f'Failed to send heartbeat signal: {e}')

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -24,10 +24,11 @@ from pathlib import Path
 from proxy.nginx import update_nginx_configs
 from proxy.endpoints import generate_endpoints
 from proxy.helper import init_default_logger, write_json
+from proxy.heartbeat import send_heartbeat
 from proxy.str_formatters import arguments_list_string
 from proxy.config import (
     CHAINS_INFO_FILEPATH, MONITOR_INTERVAL, ENDPOINT, SM_ABI_FILEPATH,
-    TMP_CHAINS_FOLDER, TMP_UPSTREAMS_FOLDER
+    TMP_CHAINS_FOLDER, TMP_UPSTREAMS_FOLDER, HEARTBEAT_URL
 )
 
 
@@ -48,6 +49,7 @@ def main():
         schains_endpoints = generate_endpoints(ENDPOINT, SM_ABI_FILEPATH)
         write_json(CHAINS_INFO_FILEPATH, schains_endpoints)
         update_nginx_configs(schains_endpoints)
+        send_heartbeat(HEARTBEAT_URL)
         logger.info(f'Proxy iteration done, sleeping for {MONITOR_INTERVAL}s...')
         sleep(MONITOR_INTERVAL)
 


### PR DESCRIPTION
This PR updates some of the proxy upstream limits:

```
proxy_read_timeout 120s -> 60s
proxy_connect_timeout 60s -> 30s
proxy_send_timeout 120s -> 60s
```

Also, optional heartbeat URL was added. 

No tests added, no performance changes.