### PR TITLE
Parse original IP in nginx config

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -5,8 +5,12 @@ events {
 worker_processes auto;
 
 http {
-	log_format upstreamlog '[$time_local] $request $status - $request_body - $host - $remote_addr to: $upstream_addr - urt: $upstream_response_time msec: $msec req_t: $request_time ($http_referer $http_user_agent)';
+	log_format upstreamlog '[$time_local] $request $status - $request_body - $host - forwarded_for: $http_x_forwarded_for - $remote_addr ($binary_remote_addr) to: $upstream_addr - urt: $upstream_response_time msec: $msec req_t: $request_time ($http_referer $http_user_agent)';
 	access_log /var/log/nginx/access.log upstreamlog;
+
+	set_real_ip_from 0.0.0.0/0;
+	real_ip_header X-Forwarded-For;
+	real_ip_recursive on;
 
 	limit_req_zone $binary_remote_addr zone=one:10m rate=200r/s;
 	limit_req_status 429;


### PR DESCRIPTION
In this PR:

- Added options to nginx config to parse original IP of the client
- Updated log format