### PR TITLE
Add timeout to Heartbeat request

### DIFF
--- a/proxy/heartbeat.py
+++ b/proxy/heartbeat.py
@@ -24,13 +24,14 @@ logger = logging.getLogger(__name__)
 
 
 def send_heartbeat(heartbeat_url):
-    if heartbeat_url is None:
-        logger.info('HEARTBEAT_URL is not set on the proxy')
-    try:
-        response = requests.get(heartbeat_url)
-        if response.status_code == 200:
-            logger.info('Heartbeat signal is successfully sent')
-        else:
-            logger.warning(f'Failed to send heartbeat signal: {response.status_code}')
-    except Exception as e:
-        logger.error(f'Failed to send heartbeat signal: {e}')
+    if heartbeat_url:
+        try:
+            response = requests.get(heartbeat_url, timeout=10)
+            if response.status_code == 200:
+                logger.info('Heartbeat signal is successfully sent')
+            else:
+                logger.warning(f'Failed to send heartbeat signal: {response.status_code}')
+        except Exception as e:
+            logger.error(f'Failed to send heartbeat signal: {e}')
+    else:
+        logger.info('HEARTBEAT_URL is not set or empty')


### PR DESCRIPTION
This pull request updates the heartbeat logic in `proxy/heartbeat.py` to improve error handling and reliability. The main change is to only attempt sending the heartbeat if a URL is provided, and to use a timeout for the request.

Heartbeat logic improvements:

* Modified `send_heartbeat` to attempt sending the heartbeat only if `heartbeat_url` is set, and added a 10-second timeout to the `requests.get` call for better reliability. Also updated logging to clarify when the URL is not set or empty.